### PR TITLE
Delete non-existent Drupal 8 "link" filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ twigDrupal(Twig);
 
 A comprehensive list of the filters is [available here](http://www.opin.ca/en/article/twig-filters-drupal-8).
 
-- link
 - t
 - trans
 - placeholder

--- a/filters/index.js
+++ b/filters/index.js
@@ -1,7 +1,6 @@
 var trans = require('./trans')
 
 module.exports = {
-  link: require('./link'),
   t: trans,
   trans: trans,
   placeholder: trans,

--- a/filters/link.js
+++ b/filters/link.js
@@ -1,3 +1,0 @@
-module.exports = function (text, url) {
-  return '<a href="' + url + '">' + text + '</a>'
-}

--- a/test/index.js
+++ b/test/index.js
@@ -8,15 +8,6 @@ describe('twig-drupal', function () {
   // Add the Twig Filters to Twig.
   twigFilters(twigPackage)
 
-  it('should use the link filter', function (done) {
-    var template = twig({
-      data: '{{ value|link("http://google.com") }}'
-    })
-    var output = template.render({value: 'Google'})
-    assert.equal(output, '<a href="http://google.com">Google</a>')
-    done()
-  })
-
   it('should use the clean_class filter', function (done) {
     var template = twig({
       data: '{{ value|clean_class }}'


### PR DESCRIPTION
In Drupal 8, `link` is a Twig function, not a filter. Furthermore, although I haven't tested it, I don't think this code would work as written, since the second argument to a Twig.js filter (`url`, in this case) is actually an _array_ of the parameters passed into the filter at calltime.