### PR TITLE
Provide dummy_passthrough filter

### DIFF
--- a/filters/dummy_passthrough.js
+++ b/filters/dummy_passthrough.js
@@ -1,0 +1,3 @@
+module.exports = function (val) {
+  return val
+}


### PR DESCRIPTION
Currently, filters/trans.js is being used as a no-op/pass-through, but that behavior is not obvious by just looking at kalastatic.yaml, it requires at least checking the code.

In order to have settings in kalastatic.yaml that are self-documenting, we should have filters/dummy_passthrough.js to make things better in that regard. trans.js is being kept, to not break existing setups.