### PR TITLE
Omit falsy attributes from link().

### DIFF
--- a/functions/link.js
+++ b/functions/link.js
@@ -4,7 +4,7 @@ module.exports = function (title, url, attributes) {
 
   // Loop through all the given attributes.
   for (let attribute in attributes) {
-    if (Object.prototype.hasOwnProperty.call(attributes, attribute) && attributes[attribute]) {
+    if (Object.prototype.hasOwnProperty.call(attributes, attribute) && attributes[attribute] && attribute !== '_keys') {
       // Support arrays in the attributes list (e.g., class), or the object's toString().
       finalAttributes += ' ' + attribute + '="' + (Array.isArray(attributes[attribute]) ? attributes[attribute].join(' ') : attributes[attribute]) + '"'
     }

--- a/functions/link.js
+++ b/functions/link.js
@@ -4,7 +4,7 @@ module.exports = function (title, url, attributes) {
 
   // Loop through all the given attributes.
   for (let attribute in attributes) {
-    if (Object.prototype.hasOwnProperty.call(attributes, attribute)) {
+    if (Object.prototype.hasOwnProperty.call(attributes, attribute) && attributes[attribute]) {
       // Support arrays in the attributes list (e.g., class), or the object's toString().
       finalAttributes += ' ' + attribute + '="' + (Array.isArray(attributes[attribute]) ? attributes[attribute].join(' ') : attributes[attribute]) + '"'
     }


### PR DESCRIPTION
Fixes issue where values of FALSE or NULL were passed through as strings instead of removing the attribute.

Example:
```
{% set link_attributes = {
    'class': link_classes,
    'aria-current': item.is_active ? 'page' : null,
  } %}
{{ link(item.title, item.url, link_attributes) }}
```

Before, resulted in `aria-current="null"`. After, omits the `aria-current` attribute when the value is null.