### PR TITLE
Emit span when link function link is <nolink>

### DIFF
--- a/functions/link.js
+++ b/functions/link.js
@@ -10,6 +10,10 @@ module.exports = function (title, url, attributes) {
     }
   }
 
+  if (url === '<nolink>') {
+    return '<span' + finalAttributes + '>' + title + '</span>';
+  }
+
   // Construct the link.
   return '<a href="' + url + '"' + finalAttributes + '>' + title + '</a>'
 }

--- a/test/index.js
+++ b/test/index.js
@@ -186,4 +186,19 @@ describe('twig-drupal', function () {
     assert.strictEqual(output, 'Visit my <a href="http://example.com" class="awesome">Site</a>!')
     done()
   })
+
+  it('should create a span when link url is <nolink>', function (done) {
+    let template = twig({
+      data: 'Visit my {{ link(title, url, attributes) }}!',
+    })
+    let output = template.render({
+      title: 'Website',
+      url: '<nolink>',
+      attributes: {
+        class: ['foo', 'bar', 'baz'],
+      },
+    })
+    assert.strictEqual(output, 'Visit my <span class="foo bar baz">Website</span>!')
+    done()
+  })
 })


### PR DESCRIPTION
In Drupal the link Twig function will emit a span if the URL is `<nolink>`, it'd be useful to replicate this behavior here.
cf. 
- https://github.com/drupal/drupal/blob/515d10367bbe5cc158153a90e7960f92c2862745/core/lib/Drupal/Core/Utility/LinkGenerator.php#L171 
- https://github.com/drupal/drupal/blob/515d10367bbe5cc158153a90e7960f92c2862745/core/lib/Drupal/Core/GeneratedNoLink.php#L8